### PR TITLE
give back error type in onGetError

### DIFF
--- a/src/events/AllEvents.php
+++ b/src/events/AllEvents.php
@@ -54,7 +54,7 @@ abstract class AllEvents
     public function onDissectPhoneFailed($mynumber) {}
     public function onGetAudio($mynumber, $from, $id, $type, $time, $name, $size, $url, $file, $mimeType, $fileHash, $duration, $acodec, $fromJID_ifGroup = null) {}
     public function onGetBroadcastLists($mynumber, $broadcastLists){}
-    public function onGetError($mynumber, $from, $id, $data) {}
+    public function onGetError($mynumber, $from, $id, $data, $errorType = null) {}
     public function onGetExtendAccount($mynumber, $kind, $status, $creation, $expiration) {}
     public function onGetFeature($mynumber, $from, $encrypt) {}
     public function onGetGroupMessage($mynumber, $from_group_jid, $from_user_jid, $id, $type, $time, $name, $body) {}

--- a/src/whatsprot.class.php
+++ b/src/whatsprot.class.php
@@ -3101,12 +3101,20 @@ class WhatsProt
             }
         }
         if ($node->getTag() == "iq" && $node->getAttribute('type') == "error") {
+            $errorType=null;
+            foreach ($this->nodeId AS $type => $nodeID) {
+                if ($nodeID == $node->getAttribute('id')) {
+                    $errorType = $type;
+                    break;
+                }
+            }
             $this->eventManager()->fire("onGetError",
                 array(
                     $this->phoneNumber,
                     $node->getAttribute('from'),
                     $node->getAttribute('id'),
-                    $node->getChild(0)
+                    $node->getChild(0),
+                    $errorType
                 ));
         }
 

--- a/src/whatsprot.class.php
+++ b/src/whatsprot.class.php
@@ -904,7 +904,7 @@ class WhatsProt
      */
     public function sendGetPrivacySettings()
     {
-        $msgId = $this->createIqId();
+        $msgId = $this->nodeId['privacy_settings'] = $this->createIqId();
         $privacyNode = new ProtocolNode("privacy", null, null, null);
         $node = new ProtocolNode("iq",
             array(
@@ -958,7 +958,7 @@ class WhatsProt
      */
     public function sendGetProfilePicture($number, $large = false)
     {
-        $msgId = $this->createIqId();
+        $msgId = $this->nodeId['getprofilepic'] = $this->createIqId();
 
         $hash = array();
         $hash["type"] = "image";
@@ -1024,7 +1024,7 @@ class WhatsProt
      */
     public function sendGetRequestLastSeen($to)
     {
-        $msgId = $this->createIqId();
+        $msgId = $this->nodeId['getlastseen'] = $this->createIqId();
 
         $queryNode = new ProtocolNode("query", null, null, null);
 
@@ -1245,6 +1245,9 @@ class WhatsProt
      */
     public function sendGetStatuses($jids)
     {
+
+        $msgId = $this->nodeId['getstatuses'] = $this->createIqId();
+
         if (!is_array($jids)) {
             $jids = array($jids);
         }
@@ -1259,7 +1262,7 @@ class WhatsProt
                 "to" => Constants::WHATSAPP_SERVER,
                 "type" => "get",
                 "xmlns" => "status",
-                "id" => $this->createIqId()
+                "id" => $msgId
             ), array(
                 new ProtocolNode("status", null, $children, null)
             ), null);


### PR DESCRIPTION
With the old 'named' msgIDs we were able to get the type of error back from it, like `preg_match('/getpicture-[0-9]+-[0-9]+/', $msgID)` to see a getProfilePic Request failed.

This PR introduces an additional parameter to the onGetError event providing the type of error.