### PR TITLE
Send receipt before fire event

### DIFF
--- a/src/whatsprot.class.php
+++ b/src/whatsprot.class.php
@@ -2603,6 +2603,9 @@ class WhatsProt
             }
             if ($node->getAttribute("type") == "text" && $node->getChild('body') != null) {
                 $author = $node->getAttribute("participant");
+                if ($autoReceipt) {
+                    $this->sendReceipt($node, $type, $author);
+                }
                 if ($author == "") {
                     //private chat message
                     $this->eventManager()->fire("onGetMessage",
@@ -2634,9 +2637,6 @@ class WhatsProt
                         ));
                 }
 
-                if ($autoReceipt) {
-                    $this->sendReceipt($node, $type, $author);
-                }
             }
             if ($node->getAttribute("type") == "text" && $node->getChild(0)->getTag() == 'enc') {
                 // TODO


### PR DESCRIPTION
Actually, if we handle the received messages and answer that, the answer message is sent before the receipt node.