### PR TITLE
always wait for response from server after sending the authresponse node

### DIFF
--- a/src/whatsprot.class.php
+++ b/src/whatsprot.class.php
@@ -2236,7 +2236,7 @@ class WhatsProt
             $this->sendNode($data);
             $this->reader->setKey($this->inputKey);
             $this->writer->setKey($this->outputKey);
-            $this->pollMessage();
+            while (!$this->pollMessage()) {};
         }
 
         if ($this->loginStatus === Constants::DISCONNECTED_STATUS) {


### PR DESCRIPTION
Sometimes the WhatsApp Server needs some time (or the network is slow) to send the `<success>` or `<failure>` response node after sending the AuthReponseNode on Login.
So much time the socket_select() in pollMessage() times out (2 Seconds).
Thus we will normally get the LoginFailureException() thrown without even knowing why (and without firing the onSuccess or onFailure events)
