### PR TITLE
Compatibility with IoC containers resolvers

### DIFF
--- a/src/events/AllEvents.php
+++ b/src/events/AllEvents.php
@@ -5,7 +5,7 @@ abstract class AllEvents
     protected $eventsToListenFor = [];
     protected $whatsProt;
 
-    public function __construct($whatsProt)
+    public function __construct(\WhatsProt $whatsProt)
     {
         $this->whatsProt = $whatsProt;
 


### PR DESCRIPTION
IoC containers will try to create an object from AllEvents class but will fail because $whatsProt has no type-hinting.