### PR TITLE
Fixed error-v1 padding bug

### DIFF
--- a/src/whatsprot.class.php
+++ b/src/whatsprot.class.php
@@ -1283,11 +1283,12 @@ class WhatsProt
 
                 if (in_array($to_num, $this->v2Jids) && !isset($this->v1Only[$to_num])) {
                     $version = '2';
-                    $plaintext = padMessage($plaintext);
+                    $alteredText = padMessage($plaintext);
                 } else {
                     $version = '1';
+                    $alteredText = $plaintext;
                 }
-                $cipherText = $sessionCipher->encrypt($plaintext);
+                $cipherText = $sessionCipher->encrypt($alteredText);
 
                 if ($cipherText instanceof WhisperMessage) {
                     $type = 'msg';


### PR DESCRIPTION
The first message send to an iOS device will throw a error-v1. Upon this error-v1 chat-api will try to resend that message. However in some cases the padded message was saved to the messagestore (because it assumed it was version 2, when it was 1). So when that message arrives at the iOS device it will have an \n prepended to it, making it look like you typed an enter as first while this was not the case.

I solved this bug by letting the encrypt method of $sessionCipher to only encrypt the $alteredText. Meaning the $plaintext variable will stay (like it should) plain text, thus the messagestore will really only save the plain text message. Whenever the error-v1 occurs again and chat-api will try to resend that message it will get the actual plain text message from the messagestore.