### PR TITLE
Fixed a bug when there was no enc child it would crash

### DIFF
--- a/src/handlers/MessageHandler.php
+++ b/src/handlers/MessageHandler.php
@@ -55,7 +55,7 @@ class MessageHandler implements Handler
                 $file_data = file_get_contents($this->node->getChild('media')->getAttribute('url'));
             }
 
-            if ($this->node->getChild('enc')->getAttribute('mediatype') == 'url') {
+            if ($this->node->getChild('enc') != null && $this->node->getChild('enc')->getAttribute('mediatype') == 'url') {
                 $this->parent->eventManager()->fire('onGetMessage',
                     [
                         $this->phoneNumber,


### PR DESCRIPTION
In some cases, when receiving an image for example from certain devices, there is no enc child available. Line 58 would then exit with a PHP fatal error could not get getAttribute() from null.

I fixed it this way, please review.