### PR TITLE
add docker in order to quickly setup envrionment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+FROM ubuntu:15.04
+MAINTAINER Shaked KleinO Orbach <klein.shaked+whatsapp@gmail.com>
+
+#Updates apt repository
+RUN apt-get update -y
+
+#Installs PHP5.6, some extensions and apcu.
+RUN apt-get install -y software-properties-common
+RUN add-apt-repository ppa:ondrej/php5-5.6
+RUN apt-get install -y vim
+RUN apt-get install -y php5  php5-dev
+
+#Installs curl, pear, wget, git, memcached and mysql-server
+RUN apt-get install -y curl php-pear wget git memcached
+
+
+#Installs PHPUnit
+RUN wget https://phar.phpunit.de/phpunit.phar
+RUN chmod +x phpunit.phar
+RUN mv phpunit.phar /usr/local/bin/phpunit
+
+#Installs Composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+#Installs PHP CodeSniffer
+RUN pear install PHP_CodeSniffer
+
+#Fetches a sample php.ini file with most configurations already good-to-go.
+RUN wget https://raw.githubusercontent.com/naroga/docker-php56/master/php.ini
+RUN rm -r /etc/php5/cli/php.ini
+RUN rm -r /etc/php5/apache2/php.ini
+RUN cp php.ini /etc/php5/cli/php.ini
+RUN cp php.ini /etc/php5/apache2/php.ini
+
+# Whatsapp dependencies
+ADD ./docker/start.sh /tmp/start.sh
+RUN chmod +x /tmp/start.sh
+RUN /tmp/start.sh
+RUN apt-get install -y ffmpeg
+RUN apt-get install -y php5-gd
+RUN apt-get install -y php5-curl
+RUN apt-get install -y libapache2-mod-php5  #php5-sockets
+RUN apt-get install -y php5-sqlite
+RUN apt-get install -y php5-mcrypt
+RUN php5enmod mcrypt
+RUN mkdir /whatsapp
+RUN cd /whatsapp && composer require whatsapp/chat-api
+
+#Tests build
+RUN php -v
+RUN phpunit --version
+RUN composer --version
+RUN phpcs --version
+RUN php -i | grep timezone
+RUN php -r "echo json_encode(get_loaded_extensions());"
+RUN php -m | grep -w --color 'curve25519\|protobuf\|crypto'

--- a/README.md
+++ b/README.md
@@ -8,9 +8,19 @@ For new WhatsApp updates check **[WhatsApp incoming updates log](https://github.
 
 **Do you like this project? Support it by donating**
 - ![Paypal](https://raw.githubusercontent.com/reek/anti-adblock-killer/gh-pages/images/paypal.png) Paypal: [Donate](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=YNVNPLE45DNG6)
-- ![btc](https://camo.githubusercontent.com/4bc31b03fc4026aa2f14e09c25c09b81e06d5e71/687474703a2f2f7777772e6d6f6e747265616c626974636f696e2e636f6d2f696d672f66617669636f6e2e69636f) Bitcoin: 1DCEpC9wYXeUGXS58qSsqKzyy7HLTTXNYe 
+- ![btc](https://camo.githubusercontent.com/4bc31b03fc4026aa2f14e09c25c09b81e06d5e71/687474703a2f2f7777772e6d6f6e747265616c626974636f696e2e636f6d2f696d672f66617669636f6e2e69636f) Bitcoin: 1DCEpC9wYXeUGXS58qSsqKzyy7HLTTXNYe
 
 ----------
+
+### Docker
+
+```sh
+./docker.sh
+docker run -i -t <hash> /bin/bash
+cd /whatsapp/vendor/whatsapp/chat-api/examples
+php exampleFunctional.php
+```
+
 ### Installation
 
 ```sh

--- a/docker.sh
+++ b/docker.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 docker-machine create --driver virtualbox whatsapp
 docker-machine env whatsapp
-eval "$(docker-machine env default)"
+eval "$(docker-machine env whatsapp)"
 docker build -t whatsapp .

--- a/docker.sh
+++ b/docker.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+docker-machine create --driver virtualbox whatsapp
+docker-machine env whatsapp
+eval "$(docker-machine env default)"
+docker build -t whatsapp .

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,0 +1,12 @@
+echo "Building whatsapp dependencies..."
+git clone https://github.com/allegro/php-protobuf.git
+cd ./php-protobuf && phpize &&  ./configure --prefix=/usr/lib/php5/20131226 && make && make install
+echo "extension=protobuf.so" > /etc/php5/mods-available/protobuf.ini
+ln -s /etc/php5/mods-available/protobuf.ini /etc/php5/cli/conf.d/20-protobuf.ini
+git clone https://github.com/mgp25/curve25519-php.git
+cd ./curve25519-php && phpize &&  ./configure --prefix=/usr/lib/php5/20131226 && make && make install
+echo "extension=curve25519.so" > /etc/php5/mods-available/curve25519.ini
+ln -s /etc/php5/mods-available/curve25519.ini /etc/php5/cli/conf.d/20-curve25519.ini
+pecl install crypto-0.2.2
+echo "extension=crypto.so" > /etc/php5/mods-available/crypto.ini
+ln -s /etc/php5/mods-available/crypto.ini /etc/php5/cli/conf.d/20-crypto.ini


### PR DESCRIPTION
This commit adds support for docker. I have noticed that many people are having a hard time to install the dependencies and figure out how to setup everything before being able to run and receive a message using Chat-API. 

If approved, would be nice to add it to the Wiki as well. 

Thank you for the great repository, 
Shaked