### PR TITLE
Update client.php

### DIFF
--- a/examples/WA CLI Client/client.php
+++ b/examples/WA CLI Client/client.php
@@ -414,8 +414,9 @@ function showContacts()
 function fgets_u($pStdn)
 {
     $pArr = [$pStdn];
-
-    if (false === ($num_changed_streams = stream_select($pArr, $write = null, $except = null, 0))) {
+    $write = null;
+    $except = null;
+    if (false === ($num_changed_streams = stream_select($pArr, $write, $except, 0))) {
         echo "\$ 001 Socket Error : UNABLE TO WATCH STDIN.\n";
 
         return false;


### PR DESCRIPTION
without this change i got this message

PHP Strict Standards:  Only variables should be passed by reference in /usr/share/php/vendor/whatsapp/chat-api/examples/WA CLI Client/client.php on line 418